### PR TITLE
[Snippet]: Issue #52

### DIFF
--- a/code/keypairs-and-wallets/sign-verify-message/sign-verify-message.preview.en.ts
+++ b/code/keypairs-and-wallets/sign-verify-message/sign-verify-message.preview.en.ts
@@ -1,0 +1,17 @@
+const keypair = Keypair.fromSecretKey(
+Uint8Array.from([
+    174, 47, 154, 16, 202, 193, 206, 113, 199, 190, 53, 133, 169, 175, 31, 56, 222, 53, 138, 189, 224, 216, 117,
+    173, 10, 149, 53, 45, 73, 251, 237, 246, 15, 185, 186, 82, 177, 240, 148, 69, 241, 227, 167, 80, 141, 89, 240,
+    121, 121, 35, 172, 247, 68, 251, 226, 218, 48, 63, 176, 109, 168, 89, 238, 135,
+  ])
+);
+
+const message = "The quick brown fox jumps over the lazy dog";
+const messageBytes = decodeUTF8(message);
+
+const signature = nacl.sign.detached(messageBytes, keypair.secretKey);
+const result = nacl.sign.detached.verify(messageBytes, signature, keypair.publicKey.toBytes());
+
+console.log(result); 
+// true
+  

--- a/code/keypairs-and-wallets/sign-verify-message/sign-verify-message.preview.en.ts
+++ b/code/keypairs-and-wallets/sign-verify-message/sign-verify-message.preview.en.ts
@@ -1,17 +1,7 @@
-const keypair = Keypair.fromSecretKey(
-Uint8Array.from([
-    174, 47, 154, 16, 202, 193, 206, 113, 199, 190, 53, 133, 169, 175, 31, 56, 222, 53, 138, 189, 224, 216, 117,
-    173, 10, 149, 53, 45, 73, 251, 237, 246, 15, 185, 186, 82, 177, 240, 148, 69, 241, 227, 167, 80, 141, 89, 240,
-    121, 121, 35, 172, 247, 68, 251, 226, 218, 48, 63, 176, 109, 168, 89, 238, 135,
-  ])
-);
-
 const message = "The quick brown fox jumps over the lazy dog";
 const messageBytes = decodeUTF8(message);
 
 const signature = nacl.sign.detached(messageBytes, keypair.secretKey);
 const result = nacl.sign.detached.verify(messageBytes, signature, keypair.publicKey.toBytes());
 
-console.log(result); 
-// true
-  
+console.log(result);  

--- a/code/keypairs-and-wallets/sign-verify-message/sign-verify-message.ts
+++ b/code/keypairs-and-wallets/sign-verify-message/sign-verify-message.ts
@@ -1,0 +1,23 @@
+import { Keypair } from "@solana/web3.js";
+import nacl from 'tweetnacl';
+import { decodeUTF8 } from "tweetnacl-util";
+
+(async () => {
+  const keypair = Keypair.fromSecretKey(
+    Uint8Array.from([
+      174, 47, 154, 16, 202, 193, 206, 113, 199, 190, 53, 133, 169, 175, 31, 56, 222, 53, 138, 189, 224, 216, 117,
+      173, 10, 149, 53, 45, 73, 251, 237, 246, 15, 185, 186, 82, 177, 240, 148, 69, 241, 227, 167, 80, 141, 89, 240,
+      121, 121, 35, 172, 247, 68, 251, 226, 218, 48, 63, 176, 109, 168, 89, 238, 135,
+    ])
+  );
+
+  const message = "The quick brown fox jumps over the lazy dog";
+  const messageBytes = decodeUTF8(message);
+
+  const signature = nacl.sign.detached(messageBytes, keypair.secretKey);
+  const result = nacl.sign.detached.verify(messageBytes, signature, keypair.publicKey.toBytes());
+
+  console.log(result);
+  // true
+
+})();

--- a/code/keypairs-and-wallets/sign-verify-message/sign-verify-message.ts
+++ b/code/keypairs-and-wallets/sign-verify-message/sign-verify-message.ts
@@ -18,6 +18,5 @@ import { decodeUTF8 } from "tweetnacl-util";
   const result = nacl.sign.detached.verify(messageBytes, signature, keypair.publicKey.toBytes());
 
   console.log(result);
-  // true
 
 })();

--- a/docs/recipes/keypairs-and-wallets.md
+++ b/docs/recipes/keypairs-and-wallets.md
@@ -273,3 +273,33 @@ take.
   </SolanaCodeGroupItem>
 
 </SolanaCodeGroup>
+
+## Sign and Verify a Message
+
+The primary function of a keypair is to sign messages and enable
+verification of the signature. Verification of a signature allows 
+the recipient to be sure that the data was signed by the owner of a
+specific private key.
+
+To do so we will import the [TweetNaCl][1] crypto library.
+
+<SolanaCodeGroup>
+   <SolanaCodeGroupItem title="TS" active>
+
+  <template v-slot:default>
+
+@[code](@/code/keypairs-and-wallets/sign-verify-message/sign-verify-message.en.ts)
+
+  </template>
+
+  <template v-slot:preview>
+
+@[code](@/code/keypairs-and-wallets/sign-verify-message/sign-verify-message.preview.en.ts)
+
+  </template>
+
+  </SolanaCodeGroupItem>
+
+</SolanaCodeGroup>
+
+[1]: https://www.npmjs.com/package/tweetnacl


### PR DESCRIPTION
Added snippet to be able to sign and verify messages using the [TweetNaCl](http://tweetnacl.cr.yp.to/) js library.

Did not add the encrypt/decrypt use-case.

