### PR TITLE
SPL Token Transfer CPI Fixed, added token_program in invoke

### DIFF
--- a/code/programs/cpi-transfer/program/src/lib.preview.rs
+++ b/code/programs/cpi-transfer/program/src/lib.preview.rs
@@ -17,6 +17,7 @@ let required_accounts_for_transfer = [
     source_token_account.clone(),
     destination_token_account.clone(),
     source_token_account_holder.clone(),
+    token_program.clone(),
 ];
 
 invoke(

--- a/code/programs/cpi-transfer/program/src/lib.rs
+++ b/code/programs/cpi-transfer/program/src/lib.rs
@@ -65,6 +65,7 @@ pub fn process_instruction(
         source_token_account.clone(),
         destination_token_account.clone(),
         source_token_account_holder.clone(),
+        token_program.clone(),
     ];
 
     // Passing the TransactionInstruction to send


### PR DESCRIPTION
So as per the solana docs and @lisenmayben  told me on discord it is important to pass the program account of the program id you are referring in the instruction you pass to invoke, added the missing token_program account in the accounts array of invoke.
![Screenshot from 2021-12-10 14-31-21](https://user-images.githubusercontent.com/15184831/145553198-3647d660-80ba-4a35-afe2-cf6bbb61db00.png)
![Screenshot from 2021-12-10 14-29-50](https://user-images.githubusercontent.com/15184831/145553204-791cf892-c8c7-42be-bf2e-aadeecf9ebe2.png)
