### PR TITLE
feat(wallet): add snippet for connecting to wallet with react

### DIFF
--- a/code/keypairs-and-wallets/connect-to-wallet/connect-to-wallet-react.en.tsx
+++ b/code/keypairs-and-wallets/connect-to-wallet/connect-to-wallet-react.en.tsx
@@ -30,8 +30,6 @@ export const Web3Provider: FC<PropsWithChildren<{}>> = ({ children }) => {
   );
 };
 
-const Routes = () => <div />;
-
 /**
  * Make sure to wrap the App with
  * ConnectionProvider, WalletProvider, and WalletModalProvider.
@@ -42,7 +40,7 @@ const Routes = () => <div />;
 export const App = () => {
   return (
     <Web3Provider>
-      <Routes />
+      <AppChild />
     </Web3Provider>
   );
 };
@@ -51,7 +49,7 @@ import { useWallet } from "@solana/wallet-adapter-react";
 import { useWalletModal } from "@solana/wallet-adapter-react-ui";
 import { MouseEventHandler } from "react";
 
-const UseConnectedWalletOrPromptUser = () => {
+const AppChild = () => {
   const { wallet } = useWallet();
   const { setVisible } = useWalletModal();
 

--- a/code/keypairs-and-wallets/connect-to-wallet/connect-to-wallet-react.en.tsx
+++ b/code/keypairs-and-wallets/connect-to-wallet/connect-to-wallet-react.en.tsx
@@ -54,7 +54,7 @@ import { MouseEventHandler } from "react";
  * Opens a built-in modal that handles the connection flow for you.
  */
 const UseConnectedWalletOrPromptUser = () => {
-  const wallet = useWallet();
+  const { wallet } = useWallet();
   const { setVisible } = useWalletModal();
 
   const onPromptClick: MouseEventHandler = (e) => {
@@ -63,7 +63,7 @@ const UseConnectedWalletOrPromptUser = () => {
   };
 
   // Prompt the user to connect their wallet
-  if (!wallet?.publicKey) {
+  if (!wallet) {
     return <button onClick={onPromptClick}>Connect Wallet</button>;
   }
 

--- a/code/keypairs-and-wallets/connect-to-wallet/connect-to-wallet-react.en.tsx
+++ b/code/keypairs-and-wallets/connect-to-wallet/connect-to-wallet-react.en.tsx
@@ -31,10 +31,13 @@ export const Web3Provider: FC<PropsWithChildren<{}>> = ({ children }) => {
 };
 
 const Routes = () => <div />;
+
 /**
- * In addition to your typical CRA setup, make sure to wrap
- * your App contents with the necessary providers from @solana/wallet-adapter-react &
- * @solana/wallet-adapter-react-ui.
+ * Make sure to wrap the App with
+ * ConnectionProvider, WalletProvider, and WalletModalProvider.
+ * 
+ * If you have a lot of Providers already, you can combine them
+ * into a single wrapper (i.e. Web3Provider) instead.
  */
 export const App = () => {
   return (
@@ -48,23 +51,18 @@ import { useWallet } from "@solana/wallet-adapter-react";
 import { useWalletModal } from "@solana/wallet-adapter-react-ui";
 import { MouseEventHandler } from "react";
 
-/**
- * Example of using the connected wallet, if any, or
- * prompting the user to connect their wallet.
- * Opens a built-in modal that handles the connection flow for you.
- */
 const UseConnectedWalletOrPromptUser = () => {
   const { wallet } = useWallet();
   const { setVisible } = useWalletModal();
 
-  const onPromptClick: MouseEventHandler = (e) => {
-    e.preventDefault();
+  // Display the connection modal
+  const onRequestConnectWallet = () => {
     setVisible(true);
   };
-
-  // Prompt the user to connect their wallet
+  
+  // Prompt user to connect wallet
   if (!wallet) {
-    return <button onClick={onPromptClick}>Connect Wallet</button>;
+    return <button onClick={onRequestConnectWallet}>Connect Wallet</button>;
   }
 
   return (

--- a/code/keypairs-and-wallets/connect-to-wallet/connect-to-wallet-react.en.tsx
+++ b/code/keypairs-and-wallets/connect-to-wallet/connect-to-wallet-react.en.tsx
@@ -1,0 +1,76 @@
+import React, { useMemo, FC, PropsWithChildren } from "react";
+import { ConnectionProvider, WalletProvider } from "@solana/wallet-adapter-react";
+import { WalletModalProvider } from "@solana/wallet-adapter-react-ui";
+import { WalletAdapterNetwork } from "@solana/wallet-adapter-base";
+import {
+  getLedgerWallet,
+  getPhantomWallet,
+  getSlopeWallet,
+  getSolflareWallet
+} from "@solana/wallet-adapter-wallets";
+import { clusterApiUrl } from "@solana/web3.js";
+
+export const Web3Provider: FC<PropsWithChildren<{}>> = ({ children }) => {
+  // Can be set to 'devnet', 'testnet', or 'mainnet-beta'
+  const endpoint = useMemo(() => clusterApiUrl(WalletAdapterNetwork.Devnet), []);
+
+  // @solana/wallet-adapter-wallets includes all the adapters but supports tree shaking --
+  // Only the wallets you configure here will be compiled into your application
+  const wallets = useMemo(
+    () => [getPhantomWallet(), getSolflareWallet(), getSlopeWallet(), getLedgerWallet()],
+    []
+  );
+
+  return (
+    <ConnectionProvider endpoint={endpoint}>
+      <WalletModalProvider>
+        <WalletProvider wallets={wallets}>{children}</WalletProvider>
+      </WalletModalProvider>
+    </ConnectionProvider>
+  );
+};
+
+const Routes = () => <div />;
+/**
+ * In addition to your typical CRA setup, make sure to wrap
+ * your App contents with the necessary providers from @solana/wallet-adapter-react &
+ * @solana/wallet-adapter-react-ui.
+ */
+export const App = () => {
+  return (
+    <Web3Provider>
+      <Routes />
+    </Web3Provider>
+  );
+};
+
+import { useWallet } from "@solana/wallet-adapter-react";
+import { useWalletModal } from "@solana/wallet-adapter-react-ui";
+import { MouseEventHandler } from "react";
+
+/**
+ * Example of using the connected wallet, if any, or
+ * prompting the user to connect their wallet.
+ * Opens a built-in modal that handles the connection flow for you.
+ */
+const UseConnectedWalletOrPromptUser = () => {
+  const wallet = useWallet();
+  const { setVisible } = useWalletModal();
+
+  const onPromptClick: MouseEventHandler = (e) => {
+    e.preventDefault();
+    setVisible(true);
+  };
+
+  // Prompt the user to connect their wallet
+  if (!wallet?.publicKey) {
+    return <button onClick={onPromptClick}>Connect Wallet</button>;
+  }
+
+  return (
+    <main>
+      <p>Wallet successfully connected!</p>
+      <p>{wallet.publicKey.toBase58()}</p>
+    </main>
+  );
+};

--- a/code/keypairs-and-wallets/connect-to-wallet/connect-to-wallet-react.preview.en.tsx
+++ b/code/keypairs-and-wallets/connect-to-wallet/connect-to-wallet-react.preview.en.tsx
@@ -1,12 +1,19 @@
 const { wallet } = useWallet();
 const { setVisible } = useWalletModal();
 
-const onPromptClick: MouseEventHandler = (e) => {
-  e.preventDefault();
+const onRequestConnectWallet = () => {
   setVisible(true);
 };
 
 // Prompt the user to connect their wallet
 if (!wallet) {
-  return <button onClick={onPromptClick}>Connect Wallet</button>;
+  return <button onClick={onRequestConnectWallet}>Connect Wallet</button>;
 }
+
+// Displays the connected wallet address
+return (
+  <main>
+    <p>Wallet successfully connected!</p>
+    <p>{wallet.publicKey.toBase58()}</p>
+  </main>
+);

--- a/code/keypairs-and-wallets/connect-to-wallet/connect-to-wallet-react.preview.en.tsx
+++ b/code/keypairs-and-wallets/connect-to-wallet/connect-to-wallet-react.preview.en.tsx
@@ -1,4 +1,4 @@
-const wallet = useWallet();
+const { wallet } = useWallet();
 const { setVisible } = useWalletModal();
 
 const onPromptClick: MouseEventHandler = (e) => {
@@ -7,6 +7,6 @@ const onPromptClick: MouseEventHandler = (e) => {
 };
 
 // Prompt the user to connect their wallet
-if (!wallet?.publicKey) {
+if (!wallet) {
   return <button onClick={onPromptClick}>Connect Wallet</button>;
 }

--- a/code/keypairs-and-wallets/connect-to-wallet/connect-to-wallet-react.preview.en.tsx
+++ b/code/keypairs-and-wallets/connect-to-wallet/connect-to-wallet-react.preview.en.tsx
@@ -1,0 +1,12 @@
+const wallet = useWallet();
+const { setVisible } = useWalletModal();
+
+const onPromptClick: MouseEventHandler = (e) => {
+  e.preventDefault();
+  setVisible(true);
+};
+
+// Prompt the user to connect their wallet
+if (!wallet?.publicKey) {
+  return <button onClick={onPromptClick}>Connect Wallet</button>;
+}

--- a/docs/recipes/keypairs-and-wallets.md
+++ b/docs/recipes/keypairs-and-wallets.md
@@ -304,22 +304,22 @@ To do so we will import the [TweetNaCl][1] crypto library.
 
 [1]: https://www.npmjs.com/package/tweetnacl
 
-## Connect to Wallet
+## Connecting to a Wallet
 
-You can easily manage wallet connections in the frontend using Solana's [wallet-adapter](https://github.com/solana-labs/wallet-adapter) packages.
+Solana's [wallet-adapter](https://github.com/solana-labs/wallet-adapter) libraries make it easy to manage wallet connections client-side.
 
 ### React
 
-Install the following NPM packages in your React app:
+This snippet requires following dependencies:
 
 - `@solana/wallet-adapter-react`
 - `@solana/wallet-adapter-react-ui`
 - `@solana/wallet-adapter-base`
 - `@solana/wallet-adapter-wallets`
 
-These React libraries export hooks and Providers that we can use to access wallet connection states, namely `useWallet`, `WalletProvider`, `useConnection`, and `ConnectionProvider`. It is required that we wrap the React App with those providers to access those connection states.
+The React wallet-adapter libraries allow us to persist and access wallet connection states through hooks and Context providers, namely, `useWallet`, `WalletProvider`, `useConnection`, and `ConnectionProvider`. The React App must be wrapped with `WalletProvider` and `ConnectionProvider`.
 
-Additionally, can use `useWalletModal` and `WalletModalProvider` from `@solana/wallet-adapter-react-ui` to prompt users to connect their wallets and it will handle that flow for us - we just have to wait for the return type of `useWallet` to be truthy.
+Additionally, we can prompt users to connect by using `useWalletModal` to toggle visibility of the connection modal and wrapping the App with `WalletModalProvider` from `@solana/wallet-adapter-react-ui`, as well. The connection modal will handle that connection flow for us, so we can just listen for when a wallet has connected. We know a wallet is connected when the `useWallet` response has a non-null `wallet` property. Vice versa, if that property is null, we know the wallet is disconnected.
 
 <SolanaCodeGroup>
    <SolanaCodeGroupItem title="TS" active>

--- a/docs/recipes/keypairs-and-wallets.md
+++ b/docs/recipes/keypairs-and-wallets.md
@@ -310,12 +310,11 @@ Solana's [wallet-adapter](https://github.com/solana-labs/wallet-adapter) librari
 
 ### React
 
-This snippet requires following dependencies:
+Run the following command to install the required dependencies:
 
-- `@solana/wallet-adapter-react`
-- `@solana/wallet-adapter-react-ui`
-- `@solana/wallet-adapter-base`
-- `@solana/wallet-adapter-wallets`
+```/bin/bash
+yarn add @solana/wallet-adapter-react @solana/wallet-adapter-react-ui @solana/wallet-adapter-base @solana/wallet-adapter-wallets
+```
 
 The React wallet-adapter libraries allow us to persist and access wallet connection states through hooks and Context providers, namely, `useWallet`, `WalletProvider`, `useConnection`, and `ConnectionProvider`. The React App must be wrapped with `WalletProvider` and `ConnectionProvider`.
 

--- a/docs/recipes/keypairs-and-wallets.md
+++ b/docs/recipes/keypairs-and-wallets.md
@@ -303,3 +303,39 @@ To do so we will import the [TweetNaCl][1] crypto library.
 </SolanaCodeGroup>
 
 [1]: https://www.npmjs.com/package/tweetnacl
+
+## Connect to Wallet
+
+You can easily manage wallet connections in the frontend using Solana's [wallet-adapter](https://github.com/solana-labs/wallet-adapter) packages.
+
+### React
+
+Install the following NPM packages in your React app:
+
+- `@solana/wallet-adapter-react`
+- `@solana/wallet-adapter-react-ui`
+- `@solana/wallet-adapter-base`
+- `@solana/wallet-adapter-wallets`
+
+These React libraries export hooks and Providers that we can use to access wallet connection states, namely `useWallet`, `WalletProvider`, `useConnection`, and `ConnectionProvider`. It is required that we wrap the React App with those providers to access those connection states.
+
+Additionally, can use `useWalletModal` and `WalletModalProvider` from `@solana/wallet-adapter-react-ui` to prompt users to connect their wallets and it will handle that flow for us - we just have to wait for the return type of `useWallet` to be truthy.
+
+<SolanaCodeGroup>
+   <SolanaCodeGroupItem title="TS" active>
+
+  <template v-slot:default>
+
+@[code](@/code/keypairs-and-wallets/connect-to-wallet/connect-to-wallet-react.en.tsx)
+
+  </template>
+
+  <template v-slot:preview>
+
+@[code](@/code/keypairs-and-wallets/connect-to-wallet/connect-to-wallet-react.preview.en.tsx)
+
+  </template>
+
+  </SolanaCodeGroupItem>
+
+</SolanaCodeGroup>


### PR DESCRIPTION
Addresses the `React` portion of #50, namely:

1. Wrapping React App with necessary providers to use the @solana/wallet-adapter-react-* packages
2. Prompting the user to connect to their wallet if they aren't connected

I'm not sure if there were more specific instructions that I missed, so let me know if I need to fix anything!