### PR TITLE
Nit: make verify-keypair.en.py more idiomatic

### DIFF
--- a/code/keypairs-and-wallets/verify-keypair/verify-keypair.en.py
+++ b/code/keypairs-and-wallets/verify-keypair/verify-keypair.en.py
@@ -11,5 +11,5 @@ keys = [
     ]
 keypair = Keypair.from_secret_key(bytes(keys))
 
-if (PublicKey.to_base58(keypair.public_key) == PublicKey.to_base58(public_key)):
-    print ("Keypair Verification Successful")
+print(keypair.public_key.to_base58() == public_key.to_base58())
+# True

--- a/code/keypairs-and-wallets/verify-keypair/verify-keypair.preview.en.py
+++ b/code/keypairs-and-wallets/verify-keypair/verify-keypair.preview.en.py
@@ -8,5 +8,5 @@ keys = [
     ]
 keypair = Keypair.from_secret_key(bytes(keys))
 
-if (PublicKey.to_base58(keypair.public_key) == PublicKey.to_base58(public_key)):
-    print ("Keypair Verification Successful")
+print(keypair.public_key.to_base58() == public_key.to_base58())
+# True


### PR DESCRIPTION
Use `public_key.to_base58()` instead of `PublicKey.to_base58(public_key)` and make the final print similar to the TS example